### PR TITLE
tech: use go mod file for ci version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version-file: "go.mod"
       - name: Install dependencies
         run: go mod download
       - name: Test with the Go CLI
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version-file: "go.mod"
       - name: Install dependencies
         run: go mod download
       - name: Build


### PR DESCRIPTION
as titled

## WHY

This ties the CI version of Go for these jobs to the version that is defined in the `go.mod` file allowing for less maintenance when upgrading Go version for the codebase. This reduces not only potential tech debt by reducing the amount of work require, but also reduces a risk of CI failures due to mismatched version between the project and the tooling, keeping both in sync at all times.